### PR TITLE
Added recipient to the list of Datastore indexes for Message which allows servlets to query Datastore by the recipient key.

### DIFF
--- a/src/main/webapp/WEB-INF/index.yaml
+++ b/src/main/webapp/WEB-INF/index.yaml
@@ -16,5 +16,6 @@ indexes:
 - kind: Message
   properties:
   - name: user
+  - name: recipient
   - name: timestamp
     direction: desc


### PR DESCRIPTION
On a [user's page]( https://sp19-codeu-28-4865.appspot.com/user-page.html?user=brianch@codeustudents.com), direct messages feed was not populating. This is because we [query](https://github.com/FluffySheep/CodeU2019-Team28/blob/master/src/main/java/com/google/codeu/data/Datastore.java#L63) Datastore filtered by a recipient. It is not possible to query by the recipient key without GCP (Google Cloud Platform) first indexing Messages by recipient.

Screenshot of fix below:
![screenshot from 2019-03-04 16-05-04](https://user-images.githubusercontent.com/2661665/53771878-1a14cd00-3e99-11e9-8676-078c2a2f242b.png)
