### PR TITLE
Adds a link to the feed and stats page in the home navigation bar.

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -26,6 +26,8 @@ limitations under the License.
     <nav>
       <ul id="navigation">
         <li><a href="/">Home</a></li>
+	<li><a href="/feed.html">Feed</a></li>
+	<li><a href="/stats.html">Stats</a></li>
       </ul>
     </nav>
     <h1>CodeU Starter Project</h1>


### PR DESCRIPTION
Before this change, the feed and stats page could only be accessed directly by url. This change adds two links to the home page navigation bar.

![screenshot from 2019-03-05 18-01-54](https://user-images.githubusercontent.com/2661665/53850754-37b56580-3f71-11e9-8057-edfa8c2e57cd.png)
